### PR TITLE
Expose the driver core as a ROS 2 component

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ find_package(ament_cmake REQUIRED)
 find_package(diagnostic_msgs REQUIRED)
 find_package(lifecycle_msgs REQUIRED)
 find_package(rclcpp REQUIRED)
+find_package(rclcpp_components REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(serial REQUIRED)
@@ -35,10 +36,15 @@ ament_target_dependencies(
   "diagnostic_msgs"
   "lifecycle_msgs"
   "rclcpp"
+  "rclcpp_components"
   "rclcpp_lifecycle"
   "sensor_msgs"
   "serial"
 )
+
+if(BUILD_SHARED_LIBS)
+  rclcpp_components_register_nodes(bno055 "bno055_driver::BNO055Driver")
+endif()
 
 # Causes the visibility macros to use dllexport rather than dllimport,
 # which is appropriate when building the dll but not consuming it.

--- a/include/bno055_driver/bno055_driver.hpp
+++ b/include/bno055_driver/bno055_driver.hpp
@@ -43,6 +43,11 @@ namespace bno055_driver
 class BNO055Driver : public rclcpp_lifecycle::LifecycleNode
 {
 public:
+  BNO055Driver();
+
+  BNO055_DRIVER_PUBLIC
+  explicit BNO055Driver(const rclcpp::NodeOptions & options);
+
   explicit BNO055Driver(
     const std::string & node_name, const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
 

--- a/package.xml
+++ b/package.xml
@@ -13,6 +13,7 @@
   <depend>diagnostic_msgs</depend>
   <depend>lifecycle_msgs</depend>
   <depend>rclcpp</depend>
+  <depend>rclcpp_components</depend>
   <depend>rclcpp_lifecycle</depend>
   <depend>sensor_msgs</depend>
   <depend>serial</depend>

--- a/src/bno055_driver.cpp
+++ b/src/bno055_driver.cpp
@@ -19,11 +19,25 @@
 #include <string>
 #include <vector>
 
+#include "rclcpp_components/register_node_macro.hpp"
+
 #define bytes_to_ushort(addr) (*reinterpret_cast<uint16_t *>(addr))
 #define bytes_to_short(addr) (*reinterpret_cast<int16_t *>(addr))
 
+RCLCPP_COMPONENTS_REGISTER_NODE(bno055_driver::BNO055Driver)
+
 namespace bno055_driver
 {
+
+BNO055Driver::BNO055Driver()
+: BNO055Driver("bno055_driver")
+{
+}
+
+BNO055Driver::BNO055Driver(const rclcpp::NodeOptions & options)
+: BNO055Driver("bno055_driver", options)
+{
+}
 
 BNO055Driver::BNO055Driver(const std::string & node_name, const rclcpp::NodeOptions & options)
 : rclcpp_lifecycle::LifecycleNode(node_name, options),

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,7 +25,7 @@ int main(int argc, char * argv[])
   rclcpp::executors::SingleThreadedExecutor exe;
 
   std::shared_ptr<bno055_driver::BNO055Driver> bno_node =
-    std::make_shared<bno055_driver::BNO055Driver>("bno055_driver");
+    std::make_shared<bno055_driver::BNO055Driver>();
 
   exe.add_node(bno_node->get_node_base_interface());
 


### PR DESCRIPTION
Information about components: https://index.ros.org/doc/ros2/Tutorials/Composition/

Note that you must build with `BUILD_SHARED_LIBS=ON` to get the component functionality. I made this optional because right now `serial`'s status as a shared lib isn't guaranteed, and would be required to build this as a shared lib without messing with `-fPIC`.

So just be sure to build your workspace with `--cmake-args -DBUILD_SHARED_LIBS=ON` if you want to use the component functionality.

The behavior of the executable node is unaffected by this change, nor `BUILD_SHARED_LIBS`.